### PR TITLE
set the serializer path in the json serializer config

### DIFF
--- a/configs/predict.yaml
+++ b/configs/predict.yaml
@@ -31,11 +31,8 @@ ckpt_path: null
 # which split from the loaded dataset will be used
 dataset_split: test
 
+# predefined path that can be used as output path for the serializer
 prediction_save_dir: ${paths.save_dir}/predictions/${name}/${dataset_split}/${now:%Y-%m-%d_%H-%M-%S}
-
-# set the output path for the serializer
-serializer:
-  path: ${prediction_save_dir}/documents.jsonl
 
 # if set, the final config including resolved paths etc. will be written to this location
 config_out_path: ${prediction_save_dir}/config.yaml

--- a/configs/serializer/json.yaml
+++ b/configs/serializer/json.yaml
@@ -1,2 +1,2 @@
 _target_: src.serializer.JsonSerializer
-path: ???
+path: ${prediction_save_dir}/documents.jsonl


### PR DESCRIPTION
This eases the creation of future serializers because we do not set the path in the default predict config anymore.