### PR TITLE
fix Iterable import for Python3.10

### DIFF
--- a/src/models/coref_hoi.py
+++ b/src/models/coref_hoi.py
@@ -1,5 +1,5 @@
 import logging
-from collections import Iterable
+from collections.abc import Iterable
 from typing import Any, Dict, List, Optional, Tuple, TypedDict
 
 import numpy as np


### PR DESCRIPTION
Iterable cannot be imported directly in Python3.10: [https://stackoverflow.com/questions/72032032/importerror-cannot-import-name-iterable-from-collections-in-python](https://stackoverflow.com/questions/72032032/importerror-cannot-import-name-iterable-from-collections-in-python)

If we do `from collections.abc import Iterable` instead of `from collections import Iterable` it should work in both Python3.9 and Python3.10.

This affects only `src/models/coref_hoi.py` for now.