### PR TITLE
introduce the env var CONLL2012_ONTONOTESV5_PREPROCESSED_DATA_DIR

### DIFF
--- a/configs/dataset/conll2012_ontonotesv5_preprocessed.yaml
+++ b/configs/dataset/conll2012_ontonotesv5_preprocessed.yaml
@@ -3,4 +3,4 @@ input:
   _target_: datasets.load_dataset
   path: dataset_builders/pie/conll2012_ontonotesv5_preprocessed
   base_dataset_kwargs:
-    data_dir: ???
+    data_dir: ${oc.env:CONLL2012_ONTONOTESV5_PREPROCESSED_DATA_DIR}/english.384.bert-base-cased


### PR DESCRIPTION
This facilitates the usage of that dataset because the variable can be set in the `.env` file and there is no need to set `dataset.input.base_dataset_kwargs.data_dir` anymore.

How-To:
The command line parameter
```
dataset.input.base_dataset_kwargs.data_dir=/home/arbi01/data/datasets/ontonotes_coref/seg_len_384
```
becomes a line in the `.env` file
```
CONLL2012_ONTONOTESV5_PREPROCESSED_DATA_DIR="/home/arbi01/projects/multi-task-knowledge-transfer/data/ontonotes_conll_preprocessed"
```
Important: Note that we leave out the last part of the path (`seg_len_384`)! This gets appended in the [dataset config](https://github.com/Cora4NLP/multi-task-knowledge-transfer/blob/conll2012_data_dir_env_var/configs/dataset/conll2012_ontonotesv5_preprocessed.yaml).

