### PR TITLE
add an experiment log

### DIFF
--- a/log.md
+++ b/log.md
@@ -1,20 +1,30 @@
 # Experimentation Log
 
-This file is meant to log the development and experimentation process of this project. Please log relevant experiments including the
-applied commands, a short motivation and a summary of any relevant outcome, or follow-up ideas, if possible.
+This file is meant to log the development and experimentation process of this project. Please log relevant experiments
+including at least a short motivation, the applied commands, and a summary of any relevant outcome or follow-up ideas.
 
-Usage: If you want to add content, please create a new section with the current date as heading (if not yet available), and maybe a
-subsection with your topic (e.g. NER, CoRef, General, Aggregation, ...), e.g.
+**Usage:** If you want to add content, please create a new section with the current date as heading (if not yet available),
+maybe add a subsection with your topic (e.g. NER, CoRef, General, Aggregation, ...) and structure your content in a
+meaning full way, e.g.
 
 ```markdown
 ## 2023-07-27
 
 ### Relation Extraction
- - short experiment to verify that the code for the simple multi-model variant is working
-    - preparation: implemented the multi-model variant of the text classification model
-    - command: `python src/train.py experiment=tacred +trainer.fast_dev_run=true`
-    - wandb (weights & biases) run: https://wandb.ai/arne/pie-example-scidtb/runs/2rsl4z9p (this is just an example!)
-    - outcome: the code works
+
+- short experiment to verify that the code for the simple multi-model variant is working
+  - preparation: implemented the multi-model variant of the text classification model
+  - command: `python src/train.py experiment=tacred +trainer.fast_dev_run=true`
+  - wandb (weights & biases) run: https://wandb.ai/arne/pie-example-scidtb/runs/2rsl4z9p (this is just an example!)
+  - artefacts, e.g.
+    - model location: `path/to/model/dir`, or
+    - serialized documents (in the case of inference): `path/to/serialized/documents.jsonl`
+  - metric values:
+    |          |    f1 |     p |     r |
+    | :------- | ----: | ----: | ----: |
+    | MACRO    | 0.347 | 0.343 | 0.354 |
+    | MICRO    | 0.497 | 0.499 | 0.494 |
+  - outcome: the code works
 ```
 
 IMPORTANT: Execute `pre-commit run -a` before committing to ensure that the markdown is formatted correctly.


### PR DESCRIPTION
As we just discussed, this PR adds an experiment log file `log.md`. I added a short introduction with an example. This fixes #30.

[rendered](https://github.com/Cora4NLP/multi-task-knowledge-transfer/blob/experiment_log/log.md)

@StalVars @tanikina @harbecke @leonhardhennig @SimonOst  Is this fine for you (I was not able to add you all as reviewers, so just tagging you)?