### PR TITLE
attention based aggregation

### DIFF
--- a/src/models/components/transformer_multi_model.py
+++ b/src/models/components/transformer_multi_model.py
@@ -73,7 +73,7 @@ class AttentionBasedAggregator(Module):
             target model embeddings are used directly as the key vectors. Defaults to True.
         project_target_value: Whether to project the target model embeddings with a linear value layer. If disabled,
             the target model embeddings are used directly as the value vectors. Defaults to True.
-        reuse_target_query_as_key: Whether to reuse the target model query vector as the key vector. Defaults to False.
+        reuse_target_query_as_key: Whether to reuse the target model query vector as the key vector. Defaults to True.
 
     Returns:
         The aggregated model output of shape (batch_size, num_tokens, output_size).


### PR DESCRIPTION
use `aggregate=attention` (or `+aggregate=attention`) with any of the multimodels

EDIT: This also implements different attention modes:
 - `token2token` (default): use token embeddings of the target model as query and the token embeddings of all models as keys
 - `token2cls`: use token embeddings of the target model as query and the cls embeddings of all models as keys
 - `cls2token`: use the cls embedding of the target model as query and the token embeddings of all models as keys
 - `cls2cls`: use the cls embedding of the target model as query and the cls embeddings of all models as keys
 - `constant2token`: use a (learned) constant query and the token embeddings of all models as keys
 - `token2constant`: use token embeddings of the target model as query and (learned) constant keys
 - `constant2cls`: use a (learned) constant query and the cls embeddings of all models as keys
 - `cls2constant`: use the cls embedding of the target model as query and (learned) constant keys
 - `constant2constant`: use a (learned) constant query and (learned) constant keys

Use them via `aggregate={type:attention,mode:token2cls}`, for instance. I tested all modes via
```
python src/train.py \
experiment=conll2012_ner-multimodel \
+model.aggregate.type=attention \
+model.aggregate.mode_query=token,cls,constant \
+model.aggregate.mode_keys=token,cls,constant \
+trainer.fast_dev_run=true \
logger=none \
--multirun
```

NOTE: Not all of the `mode`s may be useful, but I added them for the sake of completeness.

EDIT: Based on feedback from David, this has now several parameters to "promote" the target embeddings:
- `project_target_query`: Whether to project the target model embeddings with a linear query layer to get the query vector. If disabled, the target model embeddings are used directly as the query vector. Defaults to `True`.
- `project_target_key`: Whether to project the target model embeddings with a linear key layer. If disabled, the target model embeddings are used directly as the key vectors. Defaults to `True`.
- `project_target_value`: Whether to project the target model embeddings with a linear value layer. If disabled, the target model embeddings are used directly as the value vectors. Defaults to `True`.
- `reuse_target_query_as_key`: Whether to reuse the target model query vector as the key vector. Defaults to `True`.

Most noteworthy is the last one, with that we deviate from the default attention logic *per default* (the other parameters need to be switched to have deviating logic). However, we want to have the target model embeddings to have maximum attention, which we achieve by using the same projection for the target query and key.  