### PR TITLE
extractive_qa_from_scratch pipeline config

### DIFF
--- a/configs/pipeline/extractive_qa_from_scratch.yaml
+++ b/configs/pipeline/extractive_qa_from_scratch.yaml
@@ -1,0 +1,9 @@
+# example usage:
+# python src/predict.py dataset=squadv2_prepared pipeline=extractive_qa_from_scratch ++pipeline.model.model_name_or_path=deepset/bert-base-uncased-squad2 extras.enforce_tags=false
+
+defaults:
+  - /model: ../model/extractive_question_answering.yaml
+  - /taskmodule: ../taskmodule/extractive_question_answering.yaml
+
+_target_: pytorch_ie.Pipeline
+show_progress_bar: true


### PR DESCRIPTION
This PR adds the pipeline config `extractive_qa_from_scratch` which allows to easily do inference with any model from the Huggingface Hub.

Example usage:
```
python src/predict.py \
dataset=squadv2_prepared \
pipeline=extractive_qa_from_scratch \
pipeline.model.model_name_or_path=deepset/bert-base-uncased-squad2 \
pipeline.taskmodule.tokenizer_name_or_path=deepset/bert-base-uncased-squad2 \
pipeline.taskmodule.max_length=384 \
+pipeline.taskmodule.tokenize_kwargs.stride=128 \
+pipeline.device=0 \
extras.enforce_tags=false
```
This will do inference on `squadv2` with the model `deepset/bert-base-uncased-squad2` from the hub and runs on first GPU (`+pipeline.device=0`). We also use `max_length=384` and `stride=128` as mentioned in the  [[deepset/bert-base-uncased-squad2 model card](https://huggingface.co/deepset/bert-base-uncased-squad2)] .

The main motivation is to prepare some predictions to implement a useful metric for extractive QA.

cc @StalVars 