### PR TITLE
pin pytorch-ie to 0.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 #pytorch-ie>=0.19.0,<1.0.0
 # requires:
 # - https://github.com/ChristophAlt/pytorch-ie/pull/317 required for windowed tokenization (QA taskmodule)
-git+https://github.com/ChristophAlt/pytorch-ie
+pytorch-ie == 0.20.0
 # pie-utils provides some useful helper methods for pytorch-ie,
 # e.g. document processors or span utils (convert span annotations
 # to sequence encodings such as BIO, IO or BIOUL, and back).


### PR DESCRIPTION
Since https://github.com/ChristophAlt/pytorch-ie/releases/tag/v0.20.0 was released and the current version from main branch contains  some larger modifications that need some more testing.