### PR TITLE
resize token embeddings *before* freezing them (`MultiModelTextClassificationModel`)

### DIFF
--- a/src/models/components/transformer_multi_model.py
+++ b/src/models/components/transformer_multi_model.py
@@ -229,6 +229,9 @@ class TransformerMultiModel(Module):
         freeze_models: Optional[List[str]] = None,
         # A dictionary of config overrides to pass to AutoConfig.from_pretrained.
         config_overrides: Optional[Dict[str, Any]] = None,
+        # The size of the vocabulary of the tokenizer. If provided, the token embeddings of all models are resized
+        # to this size.
+        tokenizer_vocab_size: Optional[int] = None,
     ):
         super().__init__()
         if len(pretrained_models) < 1:
@@ -251,6 +254,9 @@ class TransformerMultiModel(Module):
                     for model_id in pretrained_models
                 }
             )
+
+        if tokenizer_vocab_size is not None:
+            self.resize_token_embeddings(tokenizer_vocab_size)
 
         for model_id in freeze_models or []:
             self.models[model_id].requires_grad_(False)

--- a/src/models/multi_model_text_classification.py
+++ b/src/models/multi_model_text_classification.py
@@ -31,7 +31,7 @@ class MultiModelTextClassificationModel(PyTorchIEModel):
         model_name: str,
         pretrained_models: Dict[str, str],
         num_classes: int,
-        tokenizer_vocab_size: int,
+        tokenizer_vocab_size: Optional[int] = None,
         aggregate: str = "mean",
         freeze_models: Optional[List[str]] = None,
         ignore_index: Optional[int] = None,
@@ -55,10 +55,9 @@ class MultiModelTextClassificationModel(PyTorchIEModel):
             aggregate=aggregate,
             freeze_models=freeze_models,
             config_overrides={"num_labels": num_classes},
+            # this is important because we may have added new special tokens to the tokenizer
+            tokenizer_vocab_size=tokenizer_vocab_size,
         )
-
-        # this is important because we may have added new special tokens to the tokenizer
-        self.base_models.resize_token_embeddings(tokenizer_vocab_size)
 
         classifier_dropout = (
             self.base_models.config.classifier_dropout


### PR DESCRIPTION
This will avoid un-freezing the embedding layer of a frozen model when resizing is required. Should fix the reported number of trainable parameters.