### PR TITLE
create base configs for RE and EQA multimodel experiments 

### DIFF
--- a/configs/experiment/squadv2-multimodel.yaml
+++ b/configs/experiment/squadv2-multimodel.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+# to execute this experiment run:
+# python train.py experiment=squadv2-multimodel
+
+defaults:
+  - sqadv2-multimodel_base.yaml
+
+model:
+  pretrained_models:
+    bert-base-cased: "bert-base-cased"
+    bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
+    # bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred"

--- a/configs/experiment/squadv2-multimodel_base.yaml
+++ b/configs/experiment/squadv2-multimodel_base.yaml
@@ -1,8 +1,5 @@
 # @package _global_
 
-# to execute this experiment run:
-# python train.py experiment=squadv2_multimodel
-
 defaults:
   - override /dataset: squadv2_prepared.yaml
   - override /datamodule: default.yaml
@@ -41,7 +38,4 @@ taskmodule:
 
 model:
   model_name: ${transformer_model}
-  pretrained_models:
-    bert-base-cased: "bert-base-cased"
-    bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
-    # bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred"
+  pretrained_models: ???

--- a/configs/experiment/tacred-multimodel.yaml
+++ b/configs/experiment/tacred-multimodel.yaml
@@ -25,51 +25,12 @@
 # The config is here: configs/experiments/tacred-multimodel.yaml (this file)
 
 defaults:
-  - override /dataset: tacred_prepared.yaml
-  - override /datamodule: default.yaml
-  - override /taskmodule: transformer_re_text_classification.yaml
-  - override /model: multi_model_text_classification.yaml
-  - override /callbacks: default.yaml
-  - override /logger: wandb.yaml
-  - override /trainer: default.yaml
-
-# all parameters below will be merged with parameters from default configurations set above
-# this allows you to overwrite only specified parameters
-
-# name of the run determines folder name in logs
-name: "tacred/multi_model_re_text_classification"
-
-tags: ["dataset=tacred", "model=multi_model_re_text_classification"]
-
-seed: 12345
-
-transformer_model: bert-base-cased
-
-taskmodule:
-  tokenizer_name_or_path: ${transformer_model}
+  - tacred-multimodel_base.yaml
 
 model:
-  model_name: ${transformer_model}
-  # This should be a mapping from an arbitrary model identifier to a pretrained model name or path
-  # that can be loaded with Huggingface AutoModel.from_pretrained.
   pretrained_models:
     bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
     # bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred"
     coreference: "models/pretrained/coreference"
   # freeze_models:
   #  - bert-base-cased-ner-ontonotes
-
-  # configure learning rate. Default learning rate is set in model constructor (here: MultiModelTextClassificationModel)
-  learning_rate: 2e-5
-  task_learning_rate: 2e-5
-  warmup_proportion: 0.0
-  # this is the index of the no_relation (see the taskmodule), we ignore it for F1 calculation
-  ignore_index: 0
-
-trainer:
-  min_epochs: 5
-  max_epochs: 20
-  # gradient_clip_val: 0.5
-
-datamodule:
-  batch_size: 16

--- a/configs/experiment/tacred-multimodel_base.yaml
+++ b/configs/experiment/tacred-multimodel_base.yaml
@@ -1,0 +1,48 @@
+# @package _global_
+
+defaults:
+  - override /dataset: tacred_prepared.yaml
+  - override /datamodule: default.yaml
+  - override /taskmodule: transformer_re_text_classification.yaml
+  - override /model: multi_model_text_classification.yaml
+  - override /callbacks: default.yaml
+  - override /logger: wandb.yaml
+  - override /trainer: default.yaml
+
+# all parameters below will be merged with parameters from default configurations set above
+# this allows you to overwrite only specified parameters
+
+# name of the run determines folder name in logs
+name: "tacred/multi_model_re_text_classification"
+
+tags: ["dataset=tacred", "model=multi_model_re_text_classification"]
+
+seed: 12345
+
+transformer_model: bert-base-cased
+
+taskmodule:
+  tokenizer_name_or_path: ${transformer_model}
+
+model:
+  model_name: ${transformer_model}
+  # This should be a mapping from an arbitrary model identifier to a pretrained model name or path
+  # that can be loaded with Huggingface AutoModel.from_pretrained.
+  pretrained_models: ???
+  # freeze_models:
+  #  - bert-base-cased-ner-ontonotes
+
+  # configure learning rate. Default learning rate is set in model constructor (here: MultiModelTextClassificationModel)
+  learning_rate: 2e-5
+  task_learning_rate: 2e-5
+  warmup_proportion: 0.0
+  # this is the index of the no_relation (see the taskmodule), we ignore it for F1 calculation
+  ignore_index: 0
+
+trainer:
+  min_epochs: 5
+  max_epochs: 20
+  # gradient_clip_val: 0.5
+
+datamodule:
+  batch_size: 16


### PR DESCRIPTION
... and derive the old ones from that. Also rename `squadv2_multimodel.yaml` to `squadv2-multimodel.yaml` for consistency with other configs.

The "base" variants define `model.pretrained_models: ???`, so this should simplify to execute multi-model settings via the command line or / and to create small experiment configs for them (similar to the new `tacred-multimodel.yaml` and `squadv2-multimodel.yaml`). Background: It is not easily possible to remove values from a config dictionary (`pretrained_models`), or at least I don't know how to do so.