### PR TITLE
serialize `document_type` when saving predictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,15 +126,13 @@ This will evaluate serialized documents including predicted annotations (see [In
 **Have a look into the [evaluate_documents.yaml](configs/evaluate_documents.yaml) config to see all available options**
 
 ```bash
-python src/evaluate_documents.py metric=f1 metric.layer=entities +dataset.data_dir=PATH/TO/DIR/WITH/SPLITS +dataset.document_type=TYPE.OF.DOCUMENT.IN.JSONL.FILE
+python src/evaluate_documents.py metric=f1 metric.layer=entities +dataset.data_dir=PATH/TO/DIR/WITH/SPLITS
 ```
 
 Note: By default, this utilizes the dataset provided by the
 [from_serialized_documents](configs/dataset/from_serialized_documents.yaml) configuration. This configuration is
 designed to facilitate the loading of serialized documents, as generated during the [Inference](#inference) step. It
-requires to set the parameters `document_type` and `data_dir` or `data_files`. See [here](src/document/types.py)
-for some predefined document types, but you may have one defined in the taskmodule source code of your choice.
-If you want to use a different dataset,
+requires to set the parameter `data_dir`. If you want to use a different dataset,
 you can override the `dataset` parameter as usual with any existing dataset config, e.g `dataset=conll2003`. But
 calculating the F1 score on the bare `conll2003` dataset does not make much sense, because it does not contain any
 predictions. However, it could be used with statistical metrics such as

--- a/configs/dataset/from_serialized_documents.yaml
+++ b/configs/dataset/from_serialized_documents.yaml
@@ -1,7 +1,10 @@
 _target_: pytorch_ie.DatasetDict.from_json
-document_type: ??? # src.taskmodules.extractive_question_answering.ExtractiveQADocument
 # either define data_files ...
 # data_files:
 #   test: path/to/documents.jsonl
 # ... or a data_dir
 # data_dir: path/to/directory/with/splits/as/subfolders/containing/documents.jsonl
+
+# The document_type field is required if you do not use "data_dir" or have no metadata.json file in that directory:
+# the document type depends on the task and the dataset. For example, for relation extraction, it can be:
+# document_type: pytorch_ie.documents.TextDocumentWithLabeledEntitiesRelationsAndLabeledPartitions

--- a/configs/serializer/json.yaml
+++ b/configs/serializer/json.yaml
@@ -1,2 +1,3 @@
 _target_: src.serializer.JsonSerializer
-path: ${prediction_save_dir}/${dataset_split}/documents.jsonl
+path: ${prediction_save_dir}
+split: ${dataset_split}

--- a/src/serializer/json.py
+++ b/src/serializer/json.py
@@ -1,8 +1,10 @@
 import json
 import os
-from typing import Dict, List, Sequence, Type, TypeVar
+from typing import Dict, List, Optional, Sequence, Type, TypeVar
 
 from pytorch_ie.core import Document
+from pytorch_ie.data.dataset_dict import METADATA_FILE_NAME
+from pytorch_ie.utils.hydra import resolve_optional_document_type, serialize_document_type
 
 from src.serializer.interface import DocumentSerializer
 from src.utils import get_pylogger
@@ -22,39 +24,95 @@ def as_json_lines(file_name: str) -> bool:
 
 
 class JsonSerializer(DocumentSerializer):
-    def __init__(self, path: str, **kwargs):
-        self.path = path
-        self.kwargs = kwargs
-
-    def __call__(self, documents: Sequence[Document]) -> Dict[str, str]:
-        return self.dump(documents=documents, path=self.path, **self.kwargs)
+    def __init__(self, **kwargs):
+        self.default_kwargs = kwargs
 
     @classmethod
-    def dump(cls, documents: Sequence[Document], path: str, **kwargs) -> Dict[str, str]:
+    def write(
+        cls,
+        documents: Sequence[Document],
+        path: str,
+        file_name: str = "documents.jsonl",
+        metadata_file_name: str = METADATA_FILE_NAME,
+        split: Optional[str] = None,
+        **kwargs,
+    ) -> Dict[str, str]:
         realpath = os.path.realpath(path)
         log.info(f'serialize documents to "{realpath}" ...')
-        dir_path = os.path.dirname(realpath)
-        os.makedirs(dir_path, exist_ok=True)
-        if as_json_lines(str(path)):
-            with open(realpath, "w") as f:
+        os.makedirs(realpath, exist_ok=True)
+
+        # dump metadata including the document_type
+        if len(documents) == 0:
+            raise Exception("cannot serialize empty list of documents")
+        document_type = type(documents[0])
+        metadata = {"document_type": serialize_document_type(document_type)}
+        full_metadata_file_name = os.path.join(realpath, metadata_file_name)
+        if os.path.exists(full_metadata_file_name):
+            log.warning(
+                f"metadata file {full_metadata_file_name} already exists, "
+                "it will be overwritten!"
+            )
+        with open(full_metadata_file_name, "w") as f:
+            json.dump(metadata, f, indent=2)
+
+        if split is not None:
+            realpath = os.path.join(realpath, split)
+            os.makedirs(realpath, exist_ok=True)
+        full_file_name = os.path.join(realpath, file_name)
+        if as_json_lines(file_name):
+            with open(full_file_name, "w") as f:
                 for doc in documents:
                     f.write(json.dumps(doc.asdict(), **kwargs) + "\n")
         else:
-            with open(realpath, "w") as f:
+            with open(full_file_name, "w") as f:
                 json.dump([doc.asdict() for doc in documents], fp=f, **kwargs)
-        return {"path": realpath}
+        return {"path": realpath, "file_name": file_name, "metadata_file_name": metadata_file_name}
 
     @classmethod
-    def read(cls, file_name: str, document_type: Type[D]) -> List[D]:
+    def read(
+        cls,
+        path: str,
+        document_type: Optional[Type[D]] = None,
+        file_name: str = "documents.jsonl",
+        metadata_file_name: str = METADATA_FILE_NAME,
+        split: Optional[str] = None,
+    ) -> List[D]:
+        realpath = os.path.realpath(path)
+        log.info(f'load documents from "{realpath}" ...')
+
+        # try to load metadata including the document_type
+        full_metadata_file_name = os.path.join(realpath, metadata_file_name)
+        if os.path.exists(full_metadata_file_name):
+            with open(full_metadata_file_name) as f:
+                metadata = json.load(f)
+            document_type = resolve_optional_document_type(metadata.get("document_type"))
+
+        if document_type is None:
+            raise Exception("document_type is required to load serialized documents")
+
+        if split is not None:
+            realpath = os.path.join(realpath, split)
+        full_file_name = os.path.join(realpath, file_name)
         documents = []
         if as_json_lines(str(file_name)):
-            with open(file_name) as f:
+            with open(full_file_name) as f:
                 for line in f:
                     json_dict = json.loads(line)
                     documents.append(document_type.fromdict(json_dict))
         else:
-            with open(file_name) as f:
+            with open(full_file_name) as f:
                 json_list = json.load(f)
             for json_dict in json_list:
                 documents.append(document_type.fromdict(json_dict))
         return documents
+
+    def read_with_defaults(self, **kwargs) -> List[D]:
+        all_kwargs = {**self.default_kwargs, **kwargs}
+        return self.read(**all_kwargs)
+
+    def write_with_defaults(self, **kwargs) -> Dict[str, str]:
+        all_kwargs = {**self.default_kwargs, **kwargs}
+        return self.write(**all_kwargs)
+
+    def __call__(self, documents: Sequence[Document], **kwargs) -> Dict[str, str]:
+        return self.write_with_defaults(documents=documents, **kwargs)


### PR DESCRIPTION
In combination with https://github.com/ChristophAlt/pytorch-ie/pull/346, this will mitigate the need to provide a `document_type` when loading the predictions (e.g. for evaluation). Several users reported that fiddling with the `document_type` and needing to know which one to use breaks easy adaption.

Approach: Adjust the json serializer to also write the `metadata.json` in the same fashion as `DatasetDict.to_json()` does this. Note that we can not directly use `DatasetDict.to_json()` because the output of the prediction step is no `Dataset(Dict)` but a list of documents and creating a `Dataset` out of them seems to be not trivial (may work with creating an empty dataset + `add_item()` method, but would need more logic in `pytorch-ie`). 

Requires: https://github.com/ChristophAlt/pytorch-ie/pull/346 (`pytorch-ie>=0.24.2`)

Same as https://github.com/ChristophAlt/pytorch-ie-hydra-template/pull/130.