### PR TITLE
use distinct overrides to create ids for multirun results

### DIFF
--- a/src/hydra_callbacks/save_job_return_value.py
+++ b/src/hydra_callbacks/save_job_return_value.py
@@ -157,7 +157,7 @@ class SaveJobReturnValueCallback(Callback):
     def __init__(
         self,
         filenames: Union[str, List[str]] = "job_return_value.json",
-        integrate_multirun_result: bool = False,
+        integrate_multirun_result: bool = True,
     ) -> None:
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.filenames = [filenames] if isinstance(filenames, str) else filenames


### PR DESCRIPTION
In the case that we do not want to integrate the results of multiruns (i.e. stacking the result at the most inner dimension to calculate aggregated results), but just want to append the results per run, this now gives better identifiers to each output row based on the the list of hydra `overrides` per run. We disregard the override values that are the same for all runs to save space and concatenate the remaining overrides to get the identifier.

Note: This also sets the default of `integrate_multirun_result` to false because it does not work for all scenarios.

Same as https://github.com/ChristophAlt/pytorch-ie-hydra-template/pull/131, but we keep `integrate_multirun_result = True` per default.