### PR TITLE
set `integrate_multirun_result=False` per default

### DIFF
--- a/src/hydra_callbacks/save_job_return_value.py
+++ b/src/hydra_callbacks/save_job_return_value.py
@@ -157,7 +157,7 @@ class SaveJobReturnValueCallback(Callback):
     def __init__(
         self,
         filenames: Union[str, List[str]] = "job_return_value.json",
-        integrate_multirun_result: bool = True,
+        integrate_multirun_result: bool = False,
     ) -> None:
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.filenames = [filenames] if isinstance(filenames, str) else filenames


### PR DESCRIPTION
Using `integrate_multirun_result=True` can cause issues because not all multiruns are "aggregateable". For setups where this is useful, e.g. when repeating the same run with multiple seeds to get significant results, this should be added via the command line  with `+hydra.callbacks.save_job_return.integrate_multirun_result=true`.