### PR TITLE
remove `pretrained_default_config` from experiment configs

### DIFF
--- a/configs/experiment/conll2003-multimodel.yaml
+++ b/configs/experiment/conll2003-multimodel.yaml
@@ -49,16 +49,19 @@ taskmodule:
   tokenizer_name_or_path: ${transformer_model}
 
 model:
-  pretrained_default_config: ${transformer_model}
   # This should be a mapping from an arbitrary model identifier to a pretrained model name or path
   # that can be loaded with Huggingface AutoModel.from_pretrained.
   pretrained_models:
     bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
     # copy from: /ds/text/cora4nlp/models/bert-base-cased-re-tacred-20230919-hf
     bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred-20230919-hf"
-    coreference: "models/pretrained/coreference"
+    # copy from: /ds/text/cora4nlp/models/bert-base-cased-coref-hoi
+    bert-base-cased-coref-hoi: "models/pretrained/bert-base-cased-coref-hoi"
   pretrained_configs:
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
     bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
       vocab_size: 29034
   # freeze_models:
   #  - bert-base-cased-ner-ontonotes

--- a/configs/experiment/conll2012_coref_hoi_multimodel_bert_qa.yaml
+++ b/configs/experiment/conll2012_coref_hoi_multimodel_bert_qa.yaml
@@ -4,7 +4,6 @@ defaults:
   - conll2012_coref_hoi_multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     bert-base-cased: "bert-base-cased"
     bert-base-cased-qa-squad2: "models/pretrained/bert-base-cased-qa-squad2"

--- a/configs/experiment/conll2012_coref_hoi_multimodel_mrpc.yaml
+++ b/configs/experiment/conll2012_coref_hoi_multimodel_mrpc.yaml
@@ -4,9 +4,6 @@ defaults:
   - conll2012_coref_hoi_multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     bert-base-cased: "bert-base-cased"
-    #bert-base-cased-mrpc: "models/pretrained/bert-base-cased-mrpc"
-    # TODO: check with Tatiana if this is the correct model
     bert-base-cased-mrpc: "bert-base-cased-finetuned-mrpc"

--- a/configs/experiment/conll2012_coref_hoi_multimodel_triple_bert.yaml
+++ b/configs/experiment/conll2012_coref_hoi_multimodel_triple_bert.yaml
@@ -4,7 +4,6 @@ defaults:
   - conll2012_coref_hoi_multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     bert-base-cased: "bert-base-cased"
     bert-base-cased2: "bert-base-cased"

--- a/configs/experiment/conll2012_coref_hoi_multimodel_triple_coref.yaml
+++ b/configs/experiment/conll2012_coref_hoi_multimodel_triple_coref.yaml
@@ -4,9 +4,12 @@ defaults:
   - conll2012_coref_hoi_multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     bert-base-cased: "bert-base-cased"
     bert-base-cased-coref1: "models/conll2012/coref_hoi/2023-08-01_12-39-09"
     bert-base-cased-coref2: "models/conll2012/coref_hoi/2023-08-01_15-21-06"
     bert-base-cased-coref3: "models/conll2012/coref_hoi/2023-08-01_18-03-12"
+  pretrained_configs:
+    bert-base-cased-coref1: "bert-base-cased"
+    bert-base-cased-coref2: "bert-base-cased"
+    bert-base-cased-coref3: "bert-base-cased"

--- a/configs/experiment/conll2012_ner-multimodel.yaml
+++ b/configs/experiment/conll2012_ner-multimodel.yaml
@@ -7,16 +7,19 @@ defaults:
   - conll2012_ner-multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   # This should be a mapping from an arbitrary model identifier to a pretrained model name or path
   # that can be loaded with Huggingface AutoModel.from_pretrained.
   pretrained_models:
     bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
     # copy from: /ds/text/cora4nlp/models/bert-base-cased-re-tacred-20230919-hf
     bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred-20230919-hf"
-    coreference: "models/pretrained/coreference"
+    # copy from: /ds/text/cora4nlp/models/bert-base-cased-coref-hoi
+    bert-base-cased-coref-hoi: "models/pretrained/bert-base-cased-coref-hoi"
   pretrained_configs:
     bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
       vocab_size: 29034
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
   # freeze_models:
   #  - bert-base-cased-ner-ontonotes

--- a/configs/experiment/conll2012_ner-multimodel_pretrained_ner.yaml
+++ b/configs/experiment/conll2012_ner-multimodel_pretrained_ner.yaml
@@ -4,6 +4,5 @@ defaults:
   - conll2012_ner-multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"

--- a/configs/experiment/squadv2-multimodel.yaml
+++ b/configs/experiment/squadv2-multimodel.yaml
@@ -7,7 +7,6 @@ defaults:
   - squadv2-multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     bert-base-cased: "bert-base-cased"
     bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
@@ -15,4 +14,5 @@ model:
     # bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred-20230919-hf"
   pretrained_configs:
     bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
       vocab_size: 29034

--- a/configs/experiment/tacred-multimodel.yaml
+++ b/configs/experiment/tacred-multimodel.yaml
@@ -28,14 +28,17 @@ defaults:
   - tacred-multimodel_base.yaml
 
 model:
-  pretrained_default_config: ${transformer_model}
   pretrained_models:
     # copy from: /ds/text/cora4nlp/models/bert-base-cased-re-tacred-20230919-hf
     bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred-20230919-hf"
     bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
-    coreference: "models/pretrained/coreference"
+    # copy from: /ds/text/cora4nlp/models/bert-base-cased-coref-hoi
+    bert-base-cased-coref-hoi: "models/pretrained/bert-base-cased-coref-hoi"
   pretrained_configs:
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
     bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
       vocab_size: 29034
   # freeze_models:
   #  - bert-base-cased-ner-ontonotes


### PR DESCRIPTION
Define the configs explicitly via `pretrained_configs`, if necessary (i.e. if the pretrained model was trained with the code from this repo and not with the Huggingface trainer).