### PR TITLE
set pretrained_configs in `*_multimodel_base` experiment configs

### DIFF
--- a/configs/experiment/conll2012_coref_hoi_multimodel_base.yaml
+++ b/configs/experiment/conll2012_coref_hoi_multimodel_base.yaml
@@ -66,6 +66,12 @@ model:
   pretrained_models: ???
   # freeze_models:
   #  - bert-base-cased-ner-ontonotes
+  pretrained_configs:
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
+    bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
+      vocab_size: 29034
 
 trainer:
   min_epochs: 5

--- a/configs/experiment/conll2012_ner-multimodel_base.yaml
+++ b/configs/experiment/conll2012_ner-multimodel_base.yaml
@@ -45,6 +45,12 @@ model:
   #   bert-base-cased-ner-ontonotes: "models/pretrained/bert-base-cased-ner-ontonotes"
   #   bert-base-cased-re-tacred: "models/pretrained/bert-base-cased-re-tacred"
   #   coreference: "models/pretrained/coreference"
+  pretrained_configs:
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
+    bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
+      vocab_size: 29034
   # freeze_models:
   #   - bert-base-cased-ner-ontonotes
   # configure learning rate. Default learning rate is set in model constructor (here: TransformerTokenClassificationModel)

--- a/configs/experiment/squadv2-multimodel_base.yaml
+++ b/configs/experiment/squadv2-multimodel_base.yaml
@@ -42,3 +42,9 @@ taskmodule:
 
 model:
   pretrained_models: ???
+  pretrained_configs:
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
+    bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
+      vocab_size: 29034

--- a/configs/experiment/tacred_multimodel_base.yaml
+++ b/configs/experiment/tacred_multimodel_base.yaml
@@ -39,6 +39,12 @@ model:
   pretrained_models: ???
   # freeze_models:
   #  - bert-base-cased-ner-ontonotes
+  pretrained_configs:
+    bert-base-cased-coref-hoi:
+      name_or_path: "bert-base-cased"
+    bert-base-cased-re-tacred:
+      name_or_path: "bert-base-cased"
+      vocab_size: 29034
 
   # configure learning rate. Default learning rate is set in model constructor (here: MultiModelTextClassificationModel)
   learning_rate: 2e-5


### PR DESCRIPTION
... to easily add them as other task models by just adding them to `model.pretrained_models`