### PR TITLE
implement `truncate_models` parameter for multi models

### DIFF
--- a/src/models/multi_model_coref_hoi.py
+++ b/src/models/multi_model_coref_hoi.py
@@ -73,6 +73,7 @@ class MultiModelCorefHoiModel(PyTorchIEModel):
         num_genres=None,
         aggregate: str = "mean",
         freeze_models: Optional[List[str]] = None,
+        truncate_models: Optional[Dict[str, int]] = None,
         pretrained_default_config: Optional[str] = None,
         pretrained_configs: Optional[Dict[str, Dict[str, Any]]] = None,
         model_name: Optional[str] = None,
@@ -99,6 +100,7 @@ class MultiModelCorefHoiModel(PyTorchIEModel):
             load_model_weights=not self.is_from_pretrained,
             aggregate=aggregate,
             freeze_models=freeze_models,
+            truncate_models=truncate_models,
         )
 
         self.num_genres = num_genres if num_genres else len(genres)

--- a/src/models/multi_model_extractive_question_answering.py
+++ b/src/models/multi_model_extractive_question_answering.py
@@ -37,6 +37,7 @@ class MultiModelExtractiveQuestionAnsweringModel(PyTorchIEModel):
         learning_rate: float = 1e-5,
         aggregate: str = "mean",
         freeze_models: Optional[List[str]] = None,
+        truncate_models: Optional[Dict[str, int]] = None,
         model_name: Optional[str] = None,
         **kwargs,
     ) -> None:
@@ -57,6 +58,7 @@ class MultiModelExtractiveQuestionAnsweringModel(PyTorchIEModel):
             load_model_weights=not self.is_from_pretrained,
             aggregate=aggregate,
             freeze_models=freeze_models,
+            truncate_models=truncate_models,
         )
         self.max_input_length = max_input_length
 

--- a/src/models/multi_model_text_classification.py
+++ b/src/models/multi_model_text_classification.py
@@ -35,6 +35,7 @@ class MultiModelTextClassificationModel(PyTorchIEModel):
         tokenizer_vocab_size: Optional[int] = None,
         aggregate: str = "mean",
         freeze_models: Optional[List[str]] = None,
+        truncate_models: Optional[Dict[str, int]] = None,
         ignore_index: Optional[int] = None,
         learning_rate: float = 1e-5,
         task_learning_rate: Optional[float] = None,
@@ -63,6 +64,7 @@ class MultiModelTextClassificationModel(PyTorchIEModel):
             load_model_weights=not self.is_from_pretrained,
             aggregate=aggregate,
             freeze_models=freeze_models,
+            truncate_models=truncate_models,
             # this is important because we may have added new special tokens to the tokenizer
             tokenizer_vocab_size=tokenizer_vocab_size,
         )

--- a/src/models/multi_model_token_classification.py
+++ b/src/models/multi_model_token_classification.py
@@ -38,6 +38,7 @@ class MultiModelTokenClassificationModel(PyTorchIEModel):
         pretrained_default_config: Optional[str] = None,
         aggregate: str = "mean",
         freeze_models: Optional[List[str]] = None,
+        truncate_models: Optional[Dict[str, int]] = None,
         classifier_dropout: float = 0.1,
         learning_rate: float = 1e-5,
         label_pad_token_id: int = -100,
@@ -65,6 +66,7 @@ class MultiModelTokenClassificationModel(PyTorchIEModel):
             load_model_weights=not self.is_from_pretrained,
             aggregate=aggregate,
             freeze_models=freeze_models,
+            truncate_models=truncate_models,
         )
 
         self.dropout = nn.Dropout(classifier_dropout)


### PR DESCRIPTION
This allows to truncate the loaded models at a certain layer. All layers after that are discarded. 

Usage example (fast dev run for NER task with Coref model):
```bash
python src/train.py \
experiment=conll2012_ner-multimodel_frozen+frozen_coref \
+model.truncate_models.bert-base-cased-coref-hoi=8
```
This will discard the 4 (=12-8) last layers of the coref model.

cc @leonhardhennig @StalVars @tanikina @harbecke 